### PR TITLE
A fórmula para calcular a área de uma circunferência é: area = π . ra…

### DIFF
--- a/1002.rb
+++ b/1002.rb
@@ -1,0 +1,5 @@
+pi = 3.14159
+raio = gets.chomp.to_f
+area = pi * (raio * raio)
+
+puts "A=#{format("%.4f",area)}"


### PR DESCRIPTION
…io2. Considerando para este problema que π = 3.14159:

- Efetue o cálculo da área, elevando o valor de raio ao quadrado e multiplicando por π.

Entrada
A entrada contém um valor de ponto flutuante (dupla precisão), no caso, a variável raio.

Saída
Apresentar a mensagem "A=" seguido pelo valor da variável area, conforme exemplo abaixo, com 4 casas após o ponto decimal. Utilize variáveis de dupla precisão (double). Como todos os problemas, não esqueça de imprimir o fim de linha após o resultado, caso contrário, você receberá "Presentation Error".